### PR TITLE
feat: user feedback via EmailJS

### DIFF
--- a/lib/constants/secrets.dart
+++ b/lib/constants/secrets.dart
@@ -2,5 +2,8 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 String get baseUrl => dotenv.env['BASE_URL'] ?? 'http://127.0.0.1:8000';
 
-// Session token is now managed by AuthService and stored locally
-// Use AuthService.instance.sessionToken to access it
+// EmailJS credentials
+String get emailjsServiceId => dotenv.env['EMAILJS_SERVICE_ID'] ?? '';
+String get emailjsTemplateId => dotenv.env['EMAILJS_TEMPLATE_ID'] ?? '';
+String get emailjsPublicKey => dotenv.env['EMAILJS_PUBLIC_KEY'] ?? '';
+String get emailjsPrivateKey => dotenv.env['EMAILJS_PRIVATE_KEY'] ?? '';

--- a/lib/services/feedback_service/feedback_service.dart
+++ b/lib/services/feedback_service/feedback_service.dart
@@ -1,0 +1,74 @@
+import 'package:emailjs/emailjs.dart' as emailjs;
+import 'package:flutter/material.dart';
+import '../../constants/secrets.dart';
+import '../../models/student_model.dart';
+
+enum FeedbackType { feedback, bug }
+
+class FeedbackService {
+  static final FeedbackService _instance = FeedbackService._internal();
+  static bool _initialized = false;
+
+  FeedbackService._internal() {
+    _initializeEmailJS();
+  }
+
+  factory FeedbackService() {
+    return _instance;
+  }
+
+  static FeedbackService get instance => _instance;
+
+  /// Initialize EmailJS with global settings (only once)
+  static void _initializeEmailJS() {
+    if (_initialized) return;
+
+    emailjs.init(
+      emailjs.Options(
+        publicKey: emailjsPublicKey,
+        privateKey: emailjsPrivateKey,
+      ),
+    );
+    _initialized = true;
+    debugPrint('✅ EmailJS initialized');
+  }
+
+  /// Send feedback or bug report via EmailJS
+  Future<void> sendFeedback({
+    required String feedbackType,
+    required String subject,
+    required String message,
+    required Student student,
+  }) async {
+    try {
+      // Format the current date/time
+      final now = DateTime.now();
+      final sentAt =
+          '${now.day}/${now.month}/${now.year} ${now.hour}:${now.minute}:${now.second}';
+
+      // Create template parameters
+      final Map<String, dynamic> templateParams = {
+        'feedback_type': feedbackType,
+        'student_name': student.name,
+        'student_id': student.id,
+        'student_faculty': student.faculty,
+        'student_year': student.year.isNotEmpty ? student.year : 'N/A',
+        'feedback_subject': subject,
+        'message': message,
+        'sent_at': sentAt,
+      };
+      
+      // Send email via EmailJS
+      await emailjs.send(
+        emailjsServiceId,
+        emailjsTemplateId,
+        templateParams,
+      );
+
+      debugPrint('✅ Feedback sent successfully');
+    } catch (error) {
+      debugPrint('❌ Error sending feedback: $error');
+      rethrow;
+    }
+  }
+}

--- a/lib/views/feedback_page.dart
+++ b/lib/views/feedback_page.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:provider/provider.dart';
+import '../services/feedback_service/feedback_service.dart';
+import '../view_models/student_viewmodel.dart';
+import '../widgets/modern_snackbar.dart';
 
 enum FeedbackType { feedback, bug }
 
@@ -55,17 +59,56 @@ class _FeedbackPageState extends State<FeedbackPage> {
       _isSubmitting = true;
     });
 
-    // TODO: Implement actual feedback submission (email, API, etc.)
-    // For now, simulate a delay
-    await Future.delayed(const Duration(seconds: 1));
+    try {
+      // Get student data from StudentViewModel
+      final studentViewModel = context.read<StudentViewModel>();
+      final student = studentViewModel.studentData;
 
-    setState(() {
-      _isSubmitting = false;
-    });
+      // Validate student data is available
+      if (student.id.isEmpty || student.name.isEmpty) {
+        ModernSnackBar.showError(
+          context: context,
+          message: 'Student information not available. Please try again.',
+        );
+        setState(() {
+          _isSubmitting = false;
+        });
+        return;
+      }
 
-    if (mounted) {
-      _showSuccessDialog();
+      // Send feedback via EmailJS
+      await FeedbackService.instance.sendFeedback(
+        feedbackType: widget.feedbackType == FeedbackType.bug ? 'Bug' : 'Feedback',
+        subject: _subjectController.text.trim(),
+        message: _messageController.text.trim(),
+        student: student,
+      );
+
+      setState(() {
+        _isSubmitting = false;
+      });
+
+      if (mounted) {
+        _showSuccessDialog();
+        _clearForm();
+      }
+    } catch (e) {
+      setState(() {
+        _isSubmitting = false;
+      });
+
+      if (mounted) {
+        ModernSnackBar.showError(
+          context: context,
+          message: 'Failed to submit ${widget.feedbackType == FeedbackType.bug ? 'bug report' : 'feedback'}. Please try again.',
+        );
+      }
     }
+  }
+
+  void _clearForm() {
+    _subjectController.clear();
+    _messageController.clear();
   }
 
   void _showSuccessDialog() {

--- a/lib/widgets/modern_snackbar.dart
+++ b/lib/widgets/modern_snackbar.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+/// Modern, sleek snackbar widget that can be used from anywhere in the app
+class ModernSnackBar {
+  /// Show a modern snackbar with custom icon, color, and message
+  static void show({
+    required BuildContext context,
+    required String message,
+    required IconData icon,
+    required Color color,
+    Duration duration = const Duration(seconds: 4),
+  }) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Row(
+          children: [
+            Icon(
+              icon,
+              color: Colors.white,
+              size: 24,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                message,
+                style: GoogleFonts.almarai(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w500,
+                  color: Colors.white,
+                ),
+              ),
+            ),
+          ],
+        ),
+        backgroundColor: color,
+        duration: duration,
+        elevation: 6,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        behavior: SnackBarBehavior.floating,
+        margin: const EdgeInsets.all(16),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+        ),
+      ),
+    );
+  }
+
+  /// Show error snackbar
+  static void showError({
+    required BuildContext context,
+    required String message,
+  }) {
+    show(
+      context: context,
+      message: message,
+      icon: Icons.error,
+      color: Colors.red.shade600,
+    );
+  }
+
+  /// Show success snackbar
+  static void showSuccess({
+    required BuildContext context,
+    required String message,
+  }) {
+    show(
+      context: context,
+      message: message,
+      icon: Icons.check_circle,
+      color: Colors.green.shade600,
+    );
+  }
+
+  /// Show info snackbar
+  static void showInfo({
+    required BuildContext context,
+    required String message,
+  }) {
+    show(
+      context: context,
+      message: message,
+      icon: Icons.info,
+      color: Colors.blue.shade600,
+    );
+  }
+
+  /// Show warning snackbar
+  static void showWarning({
+    required BuildContext context,
+    required String message,
+  }) {
+    show(
+      context: context,
+      message: message,
+      icon: Icons.warning,
+      color: Colors.orange.shade600,
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -137,6 +137,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  emailjs:
+    dependency: "direct main"
+    description:
+      name: emailjs
+      sha256: bca1cdde15b4413a754815a0a784e6907b2cab5f2d43b753ff492493f8be55c8
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   firebase_messaging: ^16.1.3
   flutter_local_notifications: ^21.0.0
   firebase_core: ^4.6.0
+  emailjs: ^4.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
Adds in-app feedback submission that sends an email via EmailJS with
student context (name, faculty, year) and feedback details.

## Changes
- `pubspec.yaml` — add `emailjs` dependency
- `lib/services/feedback_service/feedback_service.dart` — singleton `FeedbackService`
  with typed error handling
- `lib/widgets/modern_snackbar.dart` — reusable snackbar widget
- `lib/views/feedback_page.dart` — feedback UI with student validation,
  feedback type, and subject + message fields

## Checklist
- [ ] Tested on real device
- [X] Offline error handled gracefully