### PR TITLE
feat: exam phase support

### DIFF
--- a/lib/constants/text_styles.dart
+++ b/lib/constants/text_styles.dart
@@ -39,4 +39,18 @@ class AppTextStyles {
     fontSize: 14.0,
     fontWeight: FontWeight.w500,
   );
+
+  // Small text
+  static final TextStyle small13w500 = GoogleFonts.almarai(
+    fontSize: 13.0,
+    fontWeight: FontWeight.w500,
+  );
+  static final TextStyle small12 = GoogleFonts.almarai(
+    fontSize: 12.0,
+    fontWeight: FontWeight.normal,
+  );
+  static final TextStyle small11 = GoogleFonts.almarai(
+    fontSize: 11.0,
+    fontWeight: FontWeight.normal,
+  );
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:ecu_scholar/view_models/auth_viewmodel.dart';
 import 'package:ecu_scholar/view_models/grades_viewmodel.dart';
 import 'package:ecu_scholar/view_models/onboarding_viewmodel.dart';
 import 'package:ecu_scholar/view_models/student_viewmodel.dart';
+import 'package:ecu_scholar/view_models/exam_phase_viewmodel.dart';
 import 'package:ecu_scholar/views/auth_page.dart';
 import 'package:ecu_scholar/views/onboarding_page.dart';
 import 'package:ecu_scholar/themes/theme_provider.dart';
@@ -65,6 +66,7 @@ Future<void> main() async {
             ChangeNotifierProvider<ScheduleListViewModel>(create: (context) => ScheduleListViewModel()),
             ChangeNotifierProvider<StudentViewModel>(create: (context) => StudentViewModel()),
             ChangeNotifierProvider<GradesViewModel>(create: (context) => GradesViewModel()),
+            ChangeNotifierProvider<ExamPhaseViewModel>(create: (context) => ExamPhaseViewModel()),
           ],
           child: const MyApp(),
         ),

--- a/lib/models/exam_model.dart
+++ b/lib/models/exam_model.dart
@@ -1,0 +1,226 @@
+import 'package:flutter/material.dart';
+
+/// Represents a single exam during the exam phase
+class Exam {
+  final String courseCode;
+  final String courseName;
+  final DateTime startDateTime;  // Combined date + time (24h format from API)
+  final DateTime endDateTime;    // Combined date + time (24h format from API)
+  final String? location;
+  final String? seat;
+  final String examType; // 'Final', 'Midterm', 'Quiz'
+
+  Exam({
+    required this.courseCode,
+    required this.courseName,
+    required this.startDateTime,
+    required this.endDateTime,
+    required this.examType,
+    this.seat,
+    this.location,
+  });
+
+  /// Factory constructor to create Exam from backend API JSON response
+  /// API provides: date (ISO), start_time (HH:MM 24h), end_time (HH:MM 24h)
+  factory Exam.fromJson(Map<String, dynamic> json) {
+    // Parse the date
+    final dateStr = json['date'];
+    final DateTime examDate = dateStr is String
+        ? DateTime.parse(dateStr)
+        : dateStr as DateTime;
+    
+    // Parse start and end times (24-hour format)
+    final startTimeStr = (json['start_time'] ?? '00:00') as String;
+    final endTimeStr = (json['end_time'] ?? '00:00') as String;
+    
+    final startTimeParts = startTimeStr.split(':');
+    final endTimeParts = endTimeStr.split(':');
+    
+    final startHour = int.tryParse(startTimeParts[0]) ?? 0;
+    final startMinute = int.tryParse(startTimeParts[1]) ?? 0;
+    final endHour = int.tryParse(endTimeParts[0]) ?? 0;
+    final endMinute = int.tryParse(endTimeParts[1]) ?? 0;
+    
+    // Construct DateTime objects
+    final startDateTime = DateTime(
+      examDate.year,
+      examDate.month,
+      examDate.day,
+      startHour,
+      startMinute,
+    );
+    final endDateTime = DateTime(
+      examDate.year,
+      examDate.month,
+      examDate.day,
+      endHour,
+      endMinute,
+    );
+    
+    return Exam(
+      courseCode: json['course_code'] ?? '',
+      courseName: json['course_name'] ?? '',
+      startDateTime: startDateTime,
+      endDateTime: endDateTime,
+      // Normalize empty strings to null
+      location: (json['location'] as String?)?.isEmpty == true ? null : json['location'],
+      seat: (json['seat'] as String?)?.isEmpty == true ? null : json['seat'],
+      examType: json['exam_type'] ?? 'Final',
+    );
+  }
+
+  /// Convert to JSON for API requests
+  Map<String, dynamic> toJson() {
+    return {
+      'course_code': courseCode,
+      'course_name': courseName,
+      'start_time': '${startDateTime.hour.toString().padLeft(2, '0')}:${startDateTime.minute.toString().padLeft(2, '0')}',
+      'end_time': '${endDateTime.hour.toString().padLeft(2, '0')}:${endDateTime.minute.toString().padLeft(2, '0')}',
+      'date': startDateTime.toIso8601String(),
+      'location': location,
+      'seat': seat,
+      'exam_type': examType,
+    };
+  }
+
+  /// Check if exam is today
+  bool get isToday {
+    final now = DateTime.now();
+    return startDateTime.year == now.year &&
+        startDateTime.month == now.month &&
+        startDateTime.day == now.day;
+  }
+
+  /// Check if exam is in the future
+  bool get isFuture {
+    final now = DateTime.now();
+    return startDateTime.isAfter(now);
+  }
+
+  /// Calculate days remaining until exam
+  int get daysRemaining {
+    final now = DateTime.now();
+    final difference = startDateTime.difference(now);
+    return difference.inDays;
+  }
+
+  /// Get time range as string (e.g., "09:00 — 11:00")
+  String get timeRange {
+    final startStr = '${startDateTime.hour.toString().padLeft(2, '0')}:${startDateTime.minute.toString().padLeft(2, '0')}';
+    final endStr = '${endDateTime.hour.toString().padLeft(2, '0')}:${endDateTime.minute.toString().padLeft(2, '0')}';
+    return '$startStr — $endStr';
+  }
+
+  /// Get time range as string (e.g., "09:00 — 11:00")
+  String get startTimeRange {
+    final startStr = '${startDateTime.hour.toString().padLeft(2, '0')}:${startDateTime.minute.toString().padLeft(2, '0')}';
+    return '$startStr';
+  }
+
+  /// Get formatted location info
+  /// Both location and seat are null → "TBA"
+  /// Both location and seat are present → "location · Seat seat"
+  String getLocationDisplay() {
+    if (location == null || seat == null) {
+      return 'TBA';
+    }
+    return '$location · Seat $seat';
+  }
+
+  /// Get exam badge color based on type
+  Color get badgeColor {
+    switch (examType.toLowerCase()) {
+      case 'final':
+        return const Color(0xFF3d1010); // Dark red for Final
+      case 'midterm':
+        return const Color(0xFF2d3d1d); // Dark green for Midterm
+      case 'quiz':
+        return const Color(0xFF1d2d3d); // Dark blue for Quiz
+      default:
+        return const Color(0xFF3d1010);
+    }
+  }
+
+  /// Get exam badge text color
+  Color get badgeTextColor {
+    switch (examType.toLowerCase()) {
+      case 'final':
+        return const Color(0xFFe87070); // Light red
+      case 'midterm':
+        return const Color(0xFF70e870); // Light green
+      case 'quiz':
+        return const Color(0xFF7090e8); // Light blue
+      default:
+        return const Color(0xFFe87070);
+    }
+  }
+}
+
+/// Represents the overall exam phase information
+class ExamPhase {
+  final bool isExamPhase;
+  final String semester;
+  final String academicYear;
+  final List<Exam> exams;
+
+  ExamPhase({
+    required this.isExamPhase,
+    required this.semester,
+    required this.academicYear,
+    required this.exams,
+  });
+
+  /// Factory constructor to create ExamPhase from backend API JSON response
+  factory ExamPhase.fromJson(Map<String, dynamic> json) {
+    final examsList = <Exam>[];
+    
+    // Handle exams data - could be bool or list
+    final examsData = json['exams'];
+    if (examsData is List) {
+      examsList.addAll(
+        examsData
+            .map((e) => Exam.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+    }
+
+    return ExamPhase(
+      isExamPhase: json['exams'] is bool ? json['exams'] as bool : false,
+      semester: json['semester'] ?? '',
+      academicYear: json['academic_year'] ?? '',
+      exams: examsList,
+    );
+  }
+
+  /// Convert to JSON for API requests
+  Map<String, dynamic> toJson() {
+    return {
+      'exams': isExamPhase,
+      'semester': semester,
+      'academic_year': academicYear,
+      'exams_list': exams.map((e) => e.toJson()).toList(),
+    };
+  }
+
+  /// Get today's exam (if any)
+  Exam? get todayExam {
+    try {
+      return exams.firstWhere((e) => e.isToday);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /// Get upcoming exams (excluding today's exam)
+  List<Exam> get upcomingExams {
+    return exams
+        .where((e) => !e.isToday && e.isFuture)
+        .toList()
+      ..sort((a, b) => a.startDateTime.compareTo(b.startDateTime));
+  }
+
+  /// Get all exams sorted by date
+  List<Exam> get sortedExams {
+    return List<Exam>.from(exams)..sort((a, b) => a.startDateTime.compareTo(b.startDateTime));
+  }
+}

--- a/lib/models/exam_model.dart
+++ b/lib/models/exam_model.dart
@@ -2,29 +2,34 @@ import 'package:flutter/material.dart';
 
 /// Represents a single exam during the exam phase
 class Exam {
+  final String examId;
   final String courseCode;
   final String courseName;
   final DateTime startDateTime;  // Combined date + time (24h format from API)
   final DateTime endDateTime;    // Combined date + time (24h format from API)
-  final String? location;
-  final String? seat;
-  final String examType; // 'Final', 'Midterm', 'Quiz'
+  final String? hall;
+  final String? seatNumber;
+  final bool seatingAvailable;
+  final String examType; // 'Final', 'Midterm', 'Quiz' (derived from context)
 
   Exam({
+    required this.examId,
     required this.courseCode,
     required this.courseName,
     required this.startDateTime,
     required this.endDateTime,
-    required this.examType,
-    this.seat,
-    this.location,
+    this.hall,
+    this.seatNumber,
+    required this.seatingAvailable,
+    this.examType = 'Final',
   });
 
   /// Factory constructor to create Exam from backend API JSON response
-  /// API provides: date (ISO), start_time (HH:MM 24h), end_time (HH:MM 24h)
+  /// API provides: exam_date (YYYY-MM-DD), start_time (HH:MM 24h), end_time (HH:MM 24h)
+  /// Handles "null" string values as actual null
   factory Exam.fromJson(Map<String, dynamic> json) {
     // Parse the date
-    final dateStr = json['date'];
+    final dateStr = json['exam_date'];
     final DateTime examDate = dateStr is String
         ? DateTime.parse(dateStr)
         : dateStr as DateTime;
@@ -57,28 +62,40 @@ class Exam {
       endMinute,
     );
     
+    // Helper to convert "null" string to actual null
+    String? parseNullString(dynamic value) {
+      if (value == null) return null;
+      final str = value.toString().trim();
+      if (str.isEmpty || str.toLowerCase() == 'null') return null;
+      return str;
+    }
+    
     return Exam(
+      examId: json['exam_id'] ?? '',
       courseCode: json['course_code'] ?? '',
       courseName: json['course_name'] ?? '',
       startDateTime: startDateTime,
       endDateTime: endDateTime,
-      // Normalize empty strings to null
-      location: (json['location'] as String?)?.isEmpty == true ? null : json['location'],
-      seat: (json['seat'] as String?)?.isEmpty == true ? null : json['seat'],
-      examType: json['exam_type'] ?? 'Final',
+      // Parse nullable fields, convert "null" string to actual null
+      hall: parseNullString(json['hall']),
+      seatNumber: parseNullString(json['seat_number']),
+      seatingAvailable: json['seating_available'] ?? false,
+      examType: 'Final', // Derived from context or exam_type field if provided
     );
   }
 
   /// Convert to JSON for API requests
   Map<String, dynamic> toJson() {
     return {
+      'exam_id': examId,
       'course_code': courseCode,
       'course_name': courseName,
       'start_time': '${startDateTime.hour.toString().padLeft(2, '0')}:${startDateTime.minute.toString().padLeft(2, '0')}',
       'end_time': '${endDateTime.hour.toString().padLeft(2, '0')}:${endDateTime.minute.toString().padLeft(2, '0')}',
-      'date': startDateTime.toIso8601String(),
-      'location': location,
-      'seat': seat,
+      'exam_date': startDateTime.toIso8601String().split('T')[0],
+      'hall': hall,
+      'seat_number': seatNumber,
+      'seating_available': seatingAvailable,
       'exam_type': examType,
     };
   }
@@ -104,27 +121,24 @@ class Exam {
     return difference.inDays;
   }
 
-  /// Get time range as string (e.g., "09:00 — 11:00")
-  String get timeRange {
-    final startStr = '${startDateTime.hour.toString().padLeft(2, '0')}:${startDateTime.minute.toString().padLeft(2, '0')}';
-    final endStr = '${endDateTime.hour.toString().padLeft(2, '0')}:${endDateTime.minute.toString().padLeft(2, '0')}';
-    return '$startStr — $endStr';
-  }
+String _formatTime(DateTime dt) =>
+    '${dt.hour.toString().padLeft(2, '0')}:'
+    '${dt.minute.toString().padLeft(2, '0')}';
 
   /// Get time range as string (e.g., "09:00 — 11:00")
-  String get startTimeRange {
-    final startStr = '${startDateTime.hour.toString().padLeft(2, '0')}:${startDateTime.minute.toString().padLeft(2, '0')}';
-    return '$startStr';
-  }
+  String get timeRange => '${_formatTime(startDateTime)} — ${_formatTime(endDateTime)}';
+
+  /// Get time range as string (e.g., "09:00 — 11:00")
+  String get startTimeRange => _formatTime(startDateTime);
 
   /// Get formatted location info
-  /// Both location and seat are null → "TBA"
-  /// Both location and seat are present → "location · Seat seat"
+  /// Both hall and seatNumber are null → "TBA"
+  /// Both hall and seatNumber are present → "hall · Seat seatNumber"
   String getLocationDisplay() {
-    if (location == null || seat == null) {
+    if (hall == null || seatNumber == null) {
       return 'TBA';
     }
-    return '$location · Seat $seat';
+    return '$hall · Seat $seatNumber';
   }
 
   /// Get exam badge color based on type
@@ -200,15 +214,6 @@ class ExamPhase {
       'academic_year': academicYear,
       'exams_list': exams.map((e) => e.toJson()).toList(),
     };
-  }
-
-  /// Get today's exam (if any)
-  Exam? get todayExam {
-    try {
-      return exams.firstWhere((e) => e.isToday);
-    } catch (e) {
-      return null;
-    }
   }
 
   /// Get upcoming exams (excluding today's exam)

--- a/lib/models/phase_model.dart
+++ b/lib/models/phase_model.dart
@@ -1,0 +1,18 @@
+// lib/models/phase_model.dart
+class PhaseData {
+  final String semester;
+  final String academicYear;
+  final bool isExamPhase;
+
+  const PhaseData({
+    required this.semester,
+    required this.academicYear,
+    required this.isExamPhase,
+  });
+
+  factory PhaseData.fromJson(Map<String, dynamic> json) => PhaseData(
+    semester:     json['semester']?.toString() ?? '',
+    academicYear: json['academic_year']?.toString() ?? '',
+    isExamPhase:  json['exams'] as bool? ?? false,
+  );
+}

--- a/lib/services/remote_data_service/remote_data_service.dart
+++ b/lib/services/remote_data_service/remote_data_service.dart
@@ -2,6 +2,8 @@ import 'package:dio/dio.dart';
 import 'package:ecu_scholar/models/grade_model.dart';
 import 'package:ecu_scholar/models/schedule_model.dart';
 import 'package:ecu_scholar/models/student_model.dart';
+import 'package:ecu_scholar/models/exam_model.dart';
+import 'package:ecu_scholar/models/phase_model.dart';
 import 'package:flutter/material.dart';
 
 import '../../constants/secrets.dart';
@@ -415,48 +417,30 @@ class BackendApiService {
     }
   }
 
-  /// Fetch university academic phase (schedule or exam phase)
-  /// Returns whether current phase is exam phase and relevant metadata
-  Future<Map<String, dynamic>> getUniPhase() async {
+  /// Fetch phase information (semester, academic year, exam phase status)
+  Future<PhaseData> getPhase() async {
     try {
-      final ddio = Dio(
-        BaseOptions(
-          baseUrl:
-              'https://ecu-scholar-backend-git-feat-3f1ae9-zaghlouls-projects-892807ee.vercel.app',
-          headers: {
-            'accept': 'application/json',
-            'x-vercel-protection-bypass':
-                '7FPokghkTLqsgwtBMOBM8eS3GTE0XBYx',
-          },
-        ),
-      );
-
-      final response = await ddio.get('/phase');
-
-      final semester =
-          response.data['semester']?.toString() ?? '';
-
-      final academicYear =
-          response.data['academic_year']?.toString() ?? '';
-
-      final isExam =
-          response.data['exams'] ?? false;
-
-      debugPrint(
-        '✅ Semester data loaded - '
-        'Semester: $semester, '
-        'Academic Year: $academicYear, '
-        'Is Exam Phase: $isExam',
-      );
-
-      return {
-        'semester': semester,
-        'academic_year': academicYear,
-        'exams': isExam,
-      };
+      final response = await _dio.get('/phase');
+      return PhaseData.fromJson(response.data);
     } catch (e) {
-      debugPrint('❌ Failed to fetch semester data: $e');
+      debugPrint('❌ Failed to fetch phase data: $e');
       throw _handleDioError(e);
     }
   }
+
+  /// Fetch all exams for the current semester with seating information
+  Future<List<Exam>> getPhaseExams() async {
+    try {
+      final response = await _dio.get('/phase/exams');
+      final exams = response.data['exams'] as List<dynamic>? ?? [];
+      debugPrint('✅ Phase exams loaded — ${exams.length} exams');
+      return exams
+          .map((e) => Exam.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } catch (e) {
+      debugPrint('❌ Failed to fetch phase exams: $e');
+      throw _handleDioError(e);
+    }
+  }
+
 }

--- a/lib/services/remote_data_service/remote_data_service.dart
+++ b/lib/services/remote_data_service/remote_data_service.dart
@@ -414,4 +414,49 @@ class BackendApiService {
       rethrow;
     }
   }
+
+  /// Fetch university academic phase (schedule or exam phase)
+  /// Returns whether current phase is exam phase and relevant metadata
+  Future<Map<String, dynamic>> getUniPhase() async {
+    try {
+      final ddio = Dio(
+        BaseOptions(
+          baseUrl:
+              'https://ecu-scholar-backend-git-feat-3f1ae9-zaghlouls-projects-892807ee.vercel.app',
+          headers: {
+            'accept': 'application/json',
+            'x-vercel-protection-bypass':
+                '7FPokghkTLqsgwtBMOBM8eS3GTE0XBYx',
+          },
+        ),
+      );
+
+      final response = await ddio.get('/phase');
+
+      final semester =
+          response.data['semester']?.toString() ?? '';
+
+      final academicYear =
+          response.data['academic_year']?.toString() ?? '';
+
+      final isExam =
+          response.data['exams'] ?? false;
+
+      debugPrint(
+        '✅ Semester data loaded - '
+        'Semester: $semester, '
+        'Academic Year: $academicYear, '
+        'Is Exam Phase: $isExam',
+      );
+
+      return {
+        'semester': semester,
+        'academic_year': academicYear,
+        'exams': isExam,
+      };
+    } catch (e) {
+      debugPrint('❌ Failed to fetch semester data: $e');
+      throw _handleDioError(e);
+    }
+  }
 }

--- a/lib/view_models/exam_phase_viewmodel.dart
+++ b/lib/view_models/exam_phase_viewmodel.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:collection/collection.dart';
 import 'package:ecu_scholar/models/exam_model.dart';
 import 'package:flutter/material.dart';
 import '../services/remote_data_service/remote_data_service.dart';
@@ -19,60 +20,6 @@ class ExamPhaseViewModel extends ChangeNotifier {
   String _countdownText = '--:--:--';
   bool _timerRunning = false;
 
-  ExamPhaseViewModel() {
-    _initializeDummyExams();
-  }
-
-  /// Initialize dummy exam data for development
-  /// This will be replaced with real API data once backend is ready
-void _initializeDummyExams() {
-  _exams = [
-    // Today at 3:00 PM
-    // Exam(
-    //   courseCode: 'CS401',
-    //   courseName: 'Design & Analysis of Algorithms',
-    //   startDateTime: DateTime(2026, 5, 23, 15, 0),
-    //   endDateTime: DateTime(2026, 5, 23, 17, 0),
-    //   examType: 'Final',
-    //   location: null,
-    //   seat: null,
-    // ),
-
-    // May 26, 2026 at 9:00 AM
-    Exam(
-      courseCode: 'SE402',
-      courseName: 'Software Engineering (2)',
-      startDateTime: DateTime(2026, 5, 26, 9, 0),
-      endDateTime: DateTime(2026, 5, 26, 11, 0),
-      examType: 'Final',
-      location: null,
-      seat: null,
-    ),
-
-    // May 28, 2026 at 9:00 AM
-    Exam(
-      courseCode: 'EE405',
-      courseName: 'Electronic Design Automation',
-      startDateTime: DateTime(2026, 5, 28, 9, 0),
-      endDateTime: DateTime(2026, 5, 28, 11, 0),
-      examType: 'Final',
-      location: 'A 201',
-      seat: '12',
-    ),
-
-    // May 30, 2026 at 9:00 AM
-    Exam(
-      courseCode: 'CE403',
-      courseName: 'Control Engineering',
-      startDateTime: DateTime(2026, 5, 30, 9, 0),
-      endDateTime: DateTime(2026, 5, 30, 11, 0),
-      examType: 'Final',
-      location: 'C 305',
-      seat: '20',
-    ),
-  ];
-}
-
   // Getters
   ExamPhaseLoadingState get loadingState => _loadingState;
   String? get errorMessage => _errorMessage;
@@ -85,15 +32,10 @@ void _initializeDummyExams() {
 
   /// Get next nearest upcoming exam (today or future)
   Exam? get nextUpcomingExam {
-    try {
-      final now = DateTime.now();
-      // Find first exam that is today or in the future
-      return _exams.firstWhere(
-        (e) => e.startDateTime.isAfter(now) || _isSameDay(e.startDateTime, now),
-      );
-    } catch (e) {
-      return null;
-    }
+    final now = DateTime.now();
+    return _exams.firstWhereOrNull(
+      (e) => e.startDateTime.isAfter(now) || _isSameDay(e.startDateTime, now),
+    );
   }
 
   /// Check if date is today
@@ -127,32 +69,36 @@ void _initializeDummyExams() {
     _loadingState = ExamPhaseLoadingState.loading;
     _errorMessage = null;
     notifyListeners();
-    debugPrint('ExamPhaseViewModel: Fetching phase data...');
 
     try {
       final apiService = BackendApiService();
-      final phaseData = await apiService.getUniPhase();
 
-      _semester = phaseData['semester'] ?? '';
-      _academicYear = phaseData['academic_year'] ?? '';
-      _isExamPhase = phaseData['exams'] ?? false;
+      final phaseData = await apiService.getPhase();
+      _semester     = phaseData.semester;
+      _academicYear = phaseData.academicYear;
+      _isExamPhase  = phaseData.isExamPhase;
 
-      debugPrint(
-        '✅ ExamPhaseViewModel: Phase data loaded - '
-        'isExam=$_isExamPhase, semester=$_semester',
-      );
+      if (_isExamPhase) {
+        try {
+          _exams = await apiService.getPhaseExams();
+          debugPrint('✅ ${_exams.length} exams loaded');
+        } catch (e) {
+          debugPrint('⚠️ Failed to load exams: $e');
+          _exams = [];
+        }
+      } else {
+        _exams = [];
+      }
 
       _loadingState = ExamPhaseLoadingState.loaded;
 
-      // Start countdown timer if in exam phase
       if (_isExamPhase && nextUpcomingExam != null) {
-        debugPrint('ExamPhaseViewModel: Starting countdown timer for next exam');
         _startCountdownTimer();
       }
 
       notifyListeners();
     } catch (e) {
-      debugPrint('ExamPhaseViewModel: Error fetching phase data: $e');
+      debugPrint('❌ Error fetching phase data: $e');
       _errorMessage = e.toString();
       _loadingState = ExamPhaseLoadingState.error;
       notifyListeners();

--- a/lib/view_models/exam_phase_viewmodel.dart
+++ b/lib/view_models/exam_phase_viewmodel.dart
@@ -1,0 +1,245 @@
+import 'dart:async';
+import 'package:ecu_scholar/models/exam_model.dart';
+import 'package:flutter/material.dart';
+import '../services/remote_data_service/remote_data_service.dart';
+
+enum ExamPhaseLoadingState { initial, loading, loaded, error }
+
+class ExamPhaseViewModel extends ChangeNotifier {
+  ExamPhaseLoadingState _loadingState = ExamPhaseLoadingState.initial;
+  String? _errorMessage;
+  
+  bool _isExamPhase = false;
+  String _semester = '';
+  String _academicYear = '';
+  List<Exam> _exams = [];
+  
+  // Countdown timer for live updates
+  Timer? _countdownTimer;
+  String _countdownText = '--:--:--';
+  bool _timerRunning = false;
+
+  ExamPhaseViewModel() {
+    _initializeDummyExams();
+  }
+
+  /// Initialize dummy exam data for development
+  /// This will be replaced with real API data once backend is ready
+void _initializeDummyExams() {
+  _exams = [
+    // Today at 3:00 PM
+    // Exam(
+    //   courseCode: 'CS401',
+    //   courseName: 'Design & Analysis of Algorithms',
+    //   startDateTime: DateTime(2026, 5, 23, 15, 0),
+    //   endDateTime: DateTime(2026, 5, 23, 17, 0),
+    //   examType: 'Final',
+    //   location: null,
+    //   seat: null,
+    // ),
+
+    // May 26, 2026 at 9:00 AM
+    Exam(
+      courseCode: 'SE402',
+      courseName: 'Software Engineering (2)',
+      startDateTime: DateTime(2026, 5, 26, 9, 0),
+      endDateTime: DateTime(2026, 5, 26, 11, 0),
+      examType: 'Final',
+      location: null,
+      seat: null,
+    ),
+
+    // May 28, 2026 at 9:00 AM
+    Exam(
+      courseCode: 'EE405',
+      courseName: 'Electronic Design Automation',
+      startDateTime: DateTime(2026, 5, 28, 9, 0),
+      endDateTime: DateTime(2026, 5, 28, 11, 0),
+      examType: 'Final',
+      location: 'A 201',
+      seat: '12',
+    ),
+
+    // May 30, 2026 at 9:00 AM
+    Exam(
+      courseCode: 'CE403',
+      courseName: 'Control Engineering',
+      startDateTime: DateTime(2026, 5, 30, 9, 0),
+      endDateTime: DateTime(2026, 5, 30, 11, 0),
+      examType: 'Final',
+      location: 'C 305',
+      seat: '20',
+    ),
+  ];
+}
+
+  // Getters
+  ExamPhaseLoadingState get loadingState => _loadingState;
+  String? get errorMessage => _errorMessage;
+  bool get isLoading => _loadingState == ExamPhaseLoadingState.loading;
+  bool get isExamPhase => _isExamPhase;
+  String get semester => _semester;
+  String get academicYear => _academicYear;
+  List<Exam> get exams => _exams;
+  String get countdownText => _countdownText;
+
+  /// Get next nearest upcoming exam (today or future)
+  Exam? get nextUpcomingExam {
+    try {
+      final now = DateTime.now();
+      // Find first exam that is today or in the future
+      return _exams.firstWhere(
+        (e) => e.startDateTime.isAfter(now) || _isSameDay(e.startDateTime, now),
+      );
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /// Check if date is today
+  bool _isToday(DateTime dateTime) {
+    final now = DateTime.now();
+    return _isSameDay(dateTime, now);
+  }
+
+  /// Get upcoming exams (excluding the featured one, sorted by date)
+  List<Exam> get upcomingExams {
+    final featured = nextUpcomingExam;
+    if (featured == null) return [];
+    
+    final now = DateTime.now();
+    return _exams
+        .where((e) =>
+            (e.startDateTime.isAfter(DateTime(now.year, now.month, now.day)) ||
+                _isSameDay(e.startDateTime, now)) &&
+            e != featured)
+        .toList()
+      ..sort((a, b) => a.startDateTime.compareTo(b.startDateTime));
+  }
+
+  /// Check if two dates are the same day
+  bool _isSameDay(DateTime a, DateTime b) {
+    return a.year == b.year && a.month == b.month && a.day == b.day;
+  }
+
+  /// Fetch exam phase data from API
+  Future<void> fetchPhaseData() async {
+    _loadingState = ExamPhaseLoadingState.loading;
+    _errorMessage = null;
+    notifyListeners();
+    debugPrint('ExamPhaseViewModel: Fetching phase data...');
+
+    try {
+      final apiService = BackendApiService();
+      final phaseData = await apiService.getUniPhase();
+
+      _semester = phaseData['semester'] ?? '';
+      _academicYear = phaseData['academic_year'] ?? '';
+      _isExamPhase = phaseData['exams'] ?? false;
+
+      debugPrint(
+        '✅ ExamPhaseViewModel: Phase data loaded - '
+        'isExam=$_isExamPhase, semester=$_semester',
+      );
+
+      _loadingState = ExamPhaseLoadingState.loaded;
+
+      // Start countdown timer if in exam phase
+      if (_isExamPhase && nextUpcomingExam != null) {
+        debugPrint('ExamPhaseViewModel: Starting countdown timer for next exam');
+        _startCountdownTimer();
+      }
+
+      notifyListeners();
+    } catch (e) {
+      debugPrint('ExamPhaseViewModel: Error fetching phase data: $e');
+      _errorMessage = e.toString();
+      _loadingState = ExamPhaseLoadingState.error;
+      notifyListeners();
+    }
+  }
+
+  /// Start countdown timer for today's exam
+  void _startCountdownTimer() {
+    // Cancel existing timer if running
+    if (_timerRunning && _countdownTimer != null) {
+      _countdownTimer!.cancel();
+    }
+
+    _timerRunning = true;
+    _updateCountdown(); // Initial update
+
+    // Optimize refresh rate: seconds for today, minutes for future
+    final exam = nextUpcomingExam;
+    final refreshRate = exam != null && _isToday(exam.startDateTime)
+        ? const Duration(seconds: 1)
+        : const Duration(minutes: 1);
+
+    _countdownTimer = Timer.periodic(refreshRate, (_) {
+      _updateCountdown();
+    });
+
+    debugPrint('ExamPhaseViewModel: Countdown timer started (refresh: $refreshRate)');
+  }
+
+  /// Calculate and update countdown text
+  /// Format: HH:MM:SS for today, Xd XXh XXm for future dates
+  void _updateCountdown() {
+    final exam = nextUpcomingExam;
+    if (exam == null) {
+      _countdownText = '--:--:--';
+      notifyListeners();
+      return;
+    }
+
+    try {
+      final now = DateTime.now();
+      final timeUntilExam = exam.startDateTime.difference(now);
+
+      if (timeUntilExam.isNegative) {
+        // Exam has passed
+        _countdownText = '00:00:00';
+        if (_timerRunning && _countdownTimer != null) {
+          _countdownTimer!.cancel();
+          _timerRunning = false;
+          debugPrint('ExamPhaseViewModel: Exam time has passed, timer stopped');
+        }
+      } else {
+        // Format based on whether exam is today or future
+        if (_isToday(exam.startDateTime)) {
+          // Today: HH:MM:SS format
+          final hours = timeUntilExam.inHours;
+          final minutes = timeUntilExam.inMinutes % 60;
+          final seconds = timeUntilExam.inSeconds % 60;
+          
+          _countdownText = 
+            '${hours.toString().padLeft(2, '0')}:'
+            '${minutes.toString().padLeft(2, '0')}:'
+            '${seconds.toString().padLeft(2, '0')}';
+        } else {
+          // Future: XdXXhXXm format
+          final days = timeUntilExam.inDays;
+          final remainingHours = timeUntilExam.inHours % 24;
+          final remainingMinutes = timeUntilExam.inMinutes % 60;
+          
+          _countdownText = '${days}d ${remainingHours}h ${remainingMinutes}m';
+        }
+      }
+    } catch (e) {
+      debugPrint('ExamPhaseViewModel: Error calculating countdown: $e');
+      _countdownText = '--:--:--';
+    }
+
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    if (_timerRunning && _countdownTimer != null) {
+      _countdownTimer!.cancel();
+      _timerRunning = false;
+      debugPrint('ExamPhaseViewModel: Countdown timer disposed');
+    }
+    super.dispose();
+  }
+}

--- a/lib/views/schedule_page.dart
+++ b/lib/views/schedule_page.dart
@@ -1,5 +1,6 @@
 import 'package:ecu_scholar/views/grades_page.dart';
 import 'package:ecu_scholar/views/settings_page.dart';
+import 'package:ecu_scholar/widgets/error_widget.dart' as error_widget;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -11,6 +12,7 @@ import '../view_models/exam_phase_viewmodel.dart';
 import '../widgets/exam_phase_widget.dart';
 import '../widgets/day_schedule_widget.dart';
 import '../widgets/shared_prefs_viewer.dart';
+import '../widgets/shimmer_loading.dart';
 
 class SchedulePage extends StatefulWidget {
   const SchedulePage({super.key});
@@ -84,9 +86,27 @@ class _SchedulePageState extends State<SchedulePage> {
       ),
       body: Consumer<ExamPhaseViewModel>(
         builder: (context, examViewModel, _) {
-          // If in exam phase, show exam UI instead of schedule
-          if (examViewModel.isExamPhase && examViewModel.loadingState == ExamPhaseLoadingState.loaded) {
+          // If loading or in exam phase, show exam UI (ExamPhaseWidget handles loading/error/content states)
+          if (examViewModel.loadingState == ExamPhaseLoadingState.loading || 
+              examViewModel.isExamPhase) {
             return const ExamPhaseWidget();
+          }
+
+          // Phase fetch failed and not in exam phase → show error with RefreshIndicator
+          if (examViewModel.loadingState == ExamPhaseLoadingState.error) {
+            return RefreshIndicator(
+              onRefresh: () => examViewModel.fetchPhaseData(),
+              child: SingleChildScrollView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                child: SizedBox(
+                  height: MediaQuery.of(context).size.height * 0.8,
+                  child: error_widget.ErrorWidget(
+                    message: examViewModel.errorMessage ?? 
+                        'Failed to load exam phase.\nPull to refresh.',
+                  ),
+                ),
+              ),
+            );
           }
 
           // Otherwise show normal schedule view

--- a/lib/views/schedule_page.dart
+++ b/lib/views/schedule_page.dart
@@ -4,18 +4,13 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import '../view_models/schedule_list_viewmodel.dart';
 import '../view_models/student_viewmodel.dart';
-import '../widgets/shimmer_loading.dart';
-import '../widgets/date_picker_dialog.dart' as custom_dialog;
-import '../utils/schedule_tile.dart';
-import '../constants/text_styles.dart';
-import '../widgets/empty_schedulelist_widget.dart';
+import '../view_models/exam_phase_viewmodel.dart';
+import '../widgets/exam_phase_widget.dart';
+import '../widgets/day_schedule_widget.dart';
 import '../widgets/shared_prefs_viewer.dart';
-import '../widgets/error_widget.dart' as error_widget;
-import '../services/exceptions/api_exception.dart';
 
 class SchedulePage extends StatefulWidget {
   const SchedulePage({super.key});
@@ -25,34 +20,13 @@ class SchedulePage extends StatefulWidget {
 }
 
 class _SchedulePageState extends State<SchedulePage> {
-  late PageController _pageController;
-  late DateTime _baseDate;
-  int _currentPageIndex = 0;
-  
-  // Infinite swiping: ±6 months from today (365 days total)
-  // PageView lazily builds only visible pages (~3-5), so no performance impact
-  static const int _daysToShow = 365; // Full ±6 months range
-  static const int _initialPage = 182; // Start at day 182 (today in center)
-
   @override
   void initState() {
     super.initState();
-    // Normalize to midnight to avoid time-based offset errors
-    final now = DateTime.now();
-    _baseDate = DateTime(now.year, now.month, now.day);
-    _currentPageIndex = _initialPage;
-    _pageController = PageController(initialPage: _initialPage);
-
     // Defer data loading to after first frame to ensure context is ready
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadData();
     });
-  }
-
-  @override
-  void dispose() {
-    _pageController.dispose();
-    super.dispose();
   }
 
   Future<void> _loadData() async {
@@ -62,75 +36,16 @@ class _SchedulePageState extends State<SchedulePage> {
       if (studentViewModel.loadingState != StudentLoadingState.loaded) {
         await studentViewModel.fetchStudentData();
       }
+
+      // Fetch exam phase data
+      final examPhaseViewModel = Provider.of<ExamPhaseViewModel>(context, listen: false);
+      await examPhaseViewModel.fetchPhaseData();
+
       // Fetch schedules
-      await fetchSchedules();
+      await Provider.of<ScheduleListViewModel>(context, listen: false)
+          .fetchSchedules();
     } catch (e) {
       debugPrint('Error loading data: $e');
-    }
-  }
-
-  Future<void> fetchSchedules() async {
-    await Provider.of<ScheduleListViewModel>(context, listen: false)
-        .fetchSchedules();
-  }
-
-  /// Get date for a specific page index
-  DateTime _getDateForPage(int pageIndex) {
-    final offset = pageIndex - _initialPage;
-    return _baseDate.add(Duration(days: offset));
-  }
-
-  /// Get current displayed date
-  DateTime get _currentDate => _getDateForPage(_currentPageIndex);
-
-  /// Format day name (e.g., "Saturday")
-  String _getDayName(DateTime date) {
-    return DateFormat('EEEE').format(date);
-  }
-
-  /// Format date (e.g., "Feb 20")
-  String _getFormattedDate(DateTime date) {
-    return DateFormat('MMM d').format(date);
-  }
-
-  /// Check if date is today
-  bool _isToday(DateTime date) {
-    final now = DateTime.now();
-    return date.year == now.year &&
-        date.month == now.month &&
-        date.day == now.day;
-  }
-
-  /// Show date picker dialog and jump to selected date
-  Future<void> _openDatePicker() async {
-    final minDate = _baseDate.subtract(Duration(days: _initialPage));
-    final maxDate = _baseDate.add(Duration(days: _daysToShow - _initialPage - 1));
-
-    final selectedDate = await showDialog<DateTime>(
-      context: context,
-      builder: (context) => custom_dialog.DatePickerDialog(
-        initialDate: _currentDate,
-        minDate: minDate,
-        maxDate: maxDate,
-      ),
-    );
-
-    if (selectedDate != null) {
-      // Normalize selected date to midnight
-      final normalizedSelected = DateTime(selectedDate.year, selectedDate.month, selectedDate.day);
-      
-      // Calculate the page index - both dates are now at midnight so difference is exact
-      final offset = normalizedSelected.difference(_baseDate).inDays;
-      final pageIndex = _initialPage + offset + 1;
-
-      // Animate to the selected date's page
-      await _pageController.animateToPage(
-        pageIndex,
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.easeInOut,
-      );
-
-      debugPrint('Jumped to date: ${_getFormattedDate(normalizedSelected)} (page $pageIndex)');
     }
   }
 
@@ -167,124 +82,18 @@ class _SchedulePageState extends State<SchedulePage> {
           ),
         ],
       ),
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Date header with swipe indicators
-          _buildDateHeader(),
-          
-          // Schedule content with PageView
-          Expanded(
-            child: PageView.builder(
-              controller: _pageController,
-              itemCount: _daysToShow,
-              onPageChanged: (index) {
-                // log page change event
-                setState(() {
-                  _currentPageIndex = index;
-                });
-              },
-              itemBuilder: (context, index) {
-                final date = _getDateForPage(index);
+      body: Consumer<ExamPhaseViewModel>(
+        builder: (context, examViewModel, _) {
+          // If in exam phase, show exam UI instead of schedule
+          if (examViewModel.isExamPhase && examViewModel.loadingState == ExamPhaseLoadingState.loaded) {
+            return const ExamPhaseWidget();
+          }
 
-                return Consumer<ScheduleListViewModel>(
-                  builder: (context, viewModel, child) {
-                    if (viewModel.isLoading) {
-                      return const ScheduleShimmer();
-                    }
-
-                    // Handle error state with retry option
-                    if (viewModel.hasError) {
-                      return _buildErrorWidget(viewModel.errorMessage);
-                    }
-
-                    return _buildDaySchedule(viewModel, date);
-                  },
-                );
-              },
-            ),
-          ),
-        ],
-      ),
-      floatingActionButton: kDebugMode ? const SharedPrefsViewerButton() : null,
-    );
-  }
-
-  Widget _buildDateHeader() {
-    final date = _currentDate;
-    final isToday = _isToday(date);
-    
-    return InkWell(
-      onTap: _openDatePicker,
-      borderRadius: BorderRadius.circular(12),
-      child: Padding(
-        padding: const EdgeInsets.only(top: 14, bottom: 12, right: 12.0, left: 12.0),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Row(
-              children: [
-                Text(
-                  _getDayName(date),
-                  style: AppTextStyles.headline1,
-                ),
-                if (isToday) ...[
-                  const SizedBox(width: 8),
-                  Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-                    decoration: BoxDecoration(
-                      color: Theme.of(context).colorScheme.error,
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    child: Text(
-                      'Today',
-                      style: GoogleFonts.almarai(
-                        fontSize: 12,
-                        color: Colors.white,
-                        fontWeight: FontWeight.w500,
-                      ),
-                    ),
-                  ),
-                ],
-              ],
-            ),
-            Text(
-              _getFormattedDate(date),
-              style: AppTextStyles.bodyText1.copyWith(
-                color: Theme.of(context).colorScheme.error,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildDaySchedule(ScheduleListViewModel viewModel, DateTime date) {
-    final schedules = viewModel.getSchedulesForDate(date);
-    
-    if (schedules.isEmpty) {
-      return RefreshIndicator(
-        onRefresh: fetchSchedules,
-        child: SingleChildScrollView(
-          physics: const AlwaysScrollableScrollPhysics(),
-          child: SizedBox(
-            height: MediaQuery.of(context).size.height * 0.6,
-            child: EmptySchedulelistWidget(),
-          ),
-        ),
-      );
-    }
-
-    return RefreshIndicator(
-      onRefresh: fetchSchedules,
-      child: ListView.builder(
-        physics: const AlwaysScrollableScrollPhysics(),
-        itemCount: schedules.length,
-        itemBuilder: (context, index) {
-          return ScheduleTile(schedule: schedules[index]);
+          // Otherwise show normal schedule view
+          return const SchedulePageView();
         },
       ),
+      floatingActionButton: kDebugMode ? const SharedPrefsViewerButton() : null,
     );
   }
 
@@ -345,22 +154,5 @@ class _SchedulePageState extends State<SchedulePage> {
     } else {
       return '';
     }
-  }
-
-  Widget _buildErrorWidget(String? errorMessage) {
-    final displayMessage = errorMessage ?? 'An unexpected error occurred.\nPull to refresh.';
-
-    return RefreshIndicator(
-      onRefresh: fetchSchedules,
-      child: SingleChildScrollView(
-        physics: const AlwaysScrollableScrollPhysics(),
-        child: SizedBox(
-          height: MediaQuery.of(context).size.height * 0.6,
-          child: error_widget.ErrorWidget(
-            message: displayMessage,
-          ),
-        ),
-      ),
-    );
   }
 }

--- a/lib/widgets/date_header.dart
+++ b/lib/widgets/date_header.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:intl/intl.dart';
+import '../constants/text_styles.dart';
+
+class DateHeaderWidget extends StatelessWidget {
+  final DateTime date;
+  final bool showTodayPill;
+  final VoidCallback? onTap; // SchedulePage needs tap for date picker
+
+  const DateHeaderWidget({
+    super.key,
+    required this.date,
+    this.showTodayPill = false,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(12),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Row(
+              children: [
+                Text(
+                  DateFormat('EEEE').format(date),
+                  style: AppTextStyles.headline1,
+                ),
+                if (showTodayPill) ...[
+                  const SizedBox(width: 8),
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 2,
+                    ),
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.error,
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Text(
+                      'Today',
+                      style: GoogleFonts.almarai(
+                        fontSize: 12,
+                        color: Colors.white,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+            Text(
+              DateFormat('MMM d').format(date),
+              style: AppTextStyles.bodyText1.copyWith(
+                color: theme.colorScheme.error,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/day_schedule_widget.dart
+++ b/lib/widgets/day_schedule_widget.dart
@@ -1,0 +1,187 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../view_models/schedule_list_viewmodel.dart';
+import '../widgets/shimmer_loading.dart';
+import '../widgets/date_picker_dialog.dart' as custom_dialog;
+import 'date_header.dart';
+import '../utils/schedule_tile.dart';
+import '../widgets/empty_schedulelist_widget.dart';
+import '../widgets/error_widget.dart' as error_widget;
+
+class SchedulePageView extends StatefulWidget {
+  const SchedulePageView({super.key});
+
+  @override
+  State<SchedulePageView> createState() => _SchedulePageViewState();
+}
+
+class _SchedulePageViewState extends State<SchedulePageView> {
+  late PageController _pageController;
+  late DateTime _baseDate;
+  int _currentPageIndex = 0;
+
+  // Infinite swiping: ±6 months from today (365 days total)
+  // PageView lazily builds only visible pages (~3-5), so no performance impact
+  static const int _daysToShow = 365; // Full ±6 months range
+  static const int _initialPage = 182; // Start at day 182 (today in center)
+
+  @override
+  void initState() {
+    super.initState();
+    // Normalize to midnight to avoid time-based offset errors
+    final now = DateTime.now();
+    _baseDate = DateTime(now.year, now.month, now.day);
+    _currentPageIndex = _initialPage;
+    _pageController = PageController(initialPage: _initialPage);
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  /// Get date for a specific page index
+  DateTime _getDateForPage(int pageIndex) {
+    final offset = pageIndex - _initialPage;
+    return _baseDate.add(Duration(days: offset));
+  }
+
+  /// Get current displayed date
+  DateTime get _currentDate => _getDateForPage(_currentPageIndex);
+
+  /// Check if date is today
+  bool _isToday(DateTime date) {
+    final now = DateTime.now();
+    return date.year == now.year &&
+        date.month == now.month &&
+        date.day == now.day;
+  }
+
+  /// Show date picker dialog and jump to selected date
+  Future<void> _openDatePicker() async {
+    final minDate = _baseDate.subtract(Duration(days: _initialPage));
+    final maxDate = _baseDate.add(Duration(days: _daysToShow - _initialPage - 1));
+
+    final selectedDate = await showDialog<DateTime>(
+      context: context,
+      builder: (context) => custom_dialog.DatePickerDialog(
+        initialDate: _currentDate,
+        minDate: minDate,
+        maxDate: maxDate,
+      ),
+    );
+
+    if (selectedDate != null) {
+      // Normalize selected date to midnight
+      final normalizedSelected = DateTime(selectedDate.year, selectedDate.month, selectedDate.day);
+
+      // Calculate the page index - both dates are now at midnight so difference is exact
+      final offset = normalizedSelected.difference(_baseDate).inDays;
+      final pageIndex = _initialPage + offset + 1;
+
+      // Animate to the selected date's page
+      await _pageController.animateToPage(
+        pageIndex,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeInOut,
+      );
+
+      debugPrint('Jumped to date: ${normalizedSelected.toString()} (page $pageIndex)');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Date header with swipe indicators
+        DateHeaderWidget(
+          date: _currentDate,
+          showTodayPill: _isToday(_currentDate),
+          onTap: _openDatePicker,
+        ),
+
+        // Schedule content with PageView
+        Expanded(
+          child: PageView.builder(
+            controller: _pageController,
+            itemCount: _daysToShow,
+            onPageChanged: (index) {
+              setState(() {
+                _currentPageIndex = index;
+              });
+            },
+            itemBuilder: (context, index) {
+              final date = _getDateForPage(index);
+
+              return Consumer<ScheduleListViewModel>(
+                builder: (context, viewModel, child) {
+                  if (viewModel.isLoading) {
+                    return const ScheduleShimmer();
+                  }
+
+                  // Handle error state with retry option
+                  if (viewModel.hasError) {
+                    return _buildErrorWidget(viewModel.errorMessage);
+                  }
+
+                  return _buildDaySchedule(viewModel, date);
+                },
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDaySchedule(ScheduleListViewModel viewModel, DateTime date) {
+    final schedules = viewModel.getSchedulesForDate(date);
+
+    if (schedules.isEmpty) {
+      return RefreshIndicator(
+        onRefresh: () => Provider.of<ScheduleListViewModel>(context, listen: false)
+            .fetchSchedules(),
+        child: SingleChildScrollView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          child: SizedBox(
+            height: MediaQuery.of(context).size.height * 0.6,
+            child: EmptySchedulelistWidget(),
+          ),
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: () => Provider.of<ScheduleListViewModel>(context, listen: false)
+          .fetchSchedules(),
+      child: ListView.builder(
+        physics: const AlwaysScrollableScrollPhysics(),
+        itemCount: schedules.length,
+        itemBuilder: (context, index) {
+          return ScheduleTile(schedule: schedules[index]);
+        },
+      ),
+    );
+  }
+
+  Widget _buildErrorWidget(String? errorMessage) {
+    final displayMessage = errorMessage ?? 'An unexpected error occurred.\nPull to refresh.';
+
+    return RefreshIndicator(
+      onRefresh: () => Provider.of<ScheduleListViewModel>(context, listen: false)
+          .fetchSchedules(),
+      child: SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        child: SizedBox(
+          height: MediaQuery.of(context).size.height * 0.6,
+          child: error_widget.ErrorWidget(
+            message: displayMessage,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/exam_card.dart
+++ b/lib/widgets/exam_card.dart
@@ -1,0 +1,168 @@
+import 'package:ecu_scholar/models/exam_model.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:ecu_scholar/constants/text_styles.dart';
+
+class ExamCardWidget extends StatelessWidget {
+  final Exam exam;
+  final String countdownText;
+
+  const ExamCardWidget({
+    super.key,
+    required this.exam,
+    required this.countdownText,
+  });
+
+  /// Check if exam is today
+  bool _isToday() {
+    final now = DateTime.now();
+    return exam.startDateTime.year == now.year &&
+        exam.startDateTime.month == now.month &&
+        exam.startDateTime.day == now.day;
+  }
+
+  /// Format date as "Mon Jun 1" for future exams
+  String _formatDateWithDay() {
+    return DateFormat('EEE, MMM d').format(exam.startDateTime);
+  }
+
+  /// Get the time display text (date + time or just time)
+  String _getTimeDisplay() {
+    if (_isToday()) {
+      // Today: just show time
+      return exam.timeRange;
+    } else {
+      // Future: show date · time
+      return '${_formatDateWithDay()} · ${exam.timeRange}';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    
+    return Container(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.secondary,
+        borderRadius: BorderRadius.circular(16),
+        border: Border(
+          left: BorderSide(
+            color: theme.colorScheme.error, // App red accent
+            width: 4,
+          ),
+        ),
+      ),
+      padding: const EdgeInsets.all(16),
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Course name and badge
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Text(
+                  exam.courseName,
+                  style: AppTextStyles.subtitle1bold,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 3),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.error.withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                child: Text(
+                  exam.examType,
+                  style: AppTextStyles.small11.copyWith(
+                    fontWeight: FontWeight.w500,
+                    color: theme.colorScheme.error,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+
+          // Time with optional date
+          Row(
+            children: [
+              Icon(
+                Icons.schedule,
+                size: 14,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(width: 6),
+              Text(
+                _getTimeDisplay(),
+                style: AppTextStyles.small12.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+
+          // Location and countdown row
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              // Hall and seat info
+              Expanded(
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.door_front_door_outlined,
+                      size: 13,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                    const SizedBox(width: 5),
+                    Expanded(
+                      child: Text(
+                        exam.getLocationDisplay(),
+                        style: AppTextStyles.small12.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              // Countdown chip
+              Container(
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.error.withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      Icons.alarm,
+                      size: 13,
+                      color: theme.colorScheme.error,
+                    ),
+                    const SizedBox(width: 5),
+                    Text(
+                      countdownText,
+                      style: AppTextStyles.small12.copyWith(
+                        fontWeight: FontWeight.w500,
+                        color: theme.colorScheme.error,
+                        letterSpacing: 0.5,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/exam_phase_widget.dart
+++ b/lib/widgets/exam_phase_widget.dart
@@ -1,0 +1,114 @@
+import 'package:ecu_scholar/view_models/exam_phase_viewmodel.dart';
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:provider/provider.dart';
+import 'exam_card.dart';
+import 'upcoming_exam_card.dart';
+import 'date_header.dart';
+
+class ExamPhaseWidget extends StatelessWidget {
+  const ExamPhaseWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Date header: "Monday" + "Today" pill + date
+          DateHeaderWidget(
+            date: DateTime.now(),
+            showTodayPill: true,
+          ),
+
+          // Single Consumer for all exam phase data
+          Consumer<ExamPhaseViewModel>(
+            builder: (context, examViewModel, child) {
+              // Show featured exam (next upcoming) if exists
+              if (examViewModel.nextUpcomingExam != null) {
+                return ExamCardWidget(
+                  exam: examViewModel.nextUpcomingExam!,
+                  countdownText: examViewModel.countdownText,
+                );
+              }
+
+              // If no upcoming exams, show placeholder
+              return Container(
+                width: double.infinity,
+                margin:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 0),
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.secondary,
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border(
+                    left: BorderSide(
+                      color: theme.colorScheme.error,
+                      width: 4,
+                    ),
+                  ),
+                ),
+                child: Text(
+                  'No upcoming exams scheduled',
+                  style: GoogleFonts.almarai(
+                    fontSize: 14,
+                    color: theme.colorScheme.error,
+                  ),
+                ),
+              );
+            },
+          ),
+
+          // Upcoming exams section - included in same Consumer
+          Consumer<ExamPhaseViewModel>(
+            builder: (context, examViewModel, child) {
+              final upcomingExams = examViewModel.upcomingExams;
+
+              if (upcomingExams.isEmpty) {
+                return Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Text(
+                    'No upcoming exams',
+                    style: GoogleFonts.almarai(
+                      fontSize: 13,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                );
+              }
+
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(
+                      left: 16,
+                      right: 16,
+                      top: 20,
+                      bottom: 10,
+                    ),
+                    child: Text(
+                      'UPCOMING EXAMS',
+                      style: GoogleFonts.almarai(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w500,
+                        color: theme.colorScheme.onSurfaceVariant,
+                        letterSpacing: 0.5,
+                      ),
+                    ),
+                  ),
+                  ...upcomingExams.map(
+                    (exam) => UpcomingExamCardWidget(exam: exam),
+                  ),
+                  const SizedBox(height: 16),
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/exam_phase_widget.dart
+++ b/lib/widgets/exam_phase_widget.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'exam_card.dart';
 import 'upcoming_exam_card.dart';
 import 'date_header.dart';
+import 'shimmer_loading.dart' show ScheduleShimmer;
 
 class ExamPhaseWidget extends StatelessWidget {
   const ExamPhaseWidget({super.key});
@@ -13,29 +14,83 @@ class ExamPhaseWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     
-    return SingleChildScrollView(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Date header: "Monday" + "Today" pill + date
-          DateHeaderWidget(
-            date: DateTime.now(),
-            showTodayPill: true,
+    return Consumer<ExamPhaseViewModel>(
+      builder: (context, examViewModel, child) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Date header: Always visible, OUTSIDE RefreshIndicator
+            DateHeaderWidget(
+              date: DateTime.now(),
+              showTodayPill: true,
+            ),
+
+            // Content area with RefreshIndicator
+            Expanded(
+              child: _buildContent(context, examViewModel, theme),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildContent(
+    BuildContext context,
+    ExamPhaseViewModel examViewModel,
+    ThemeData theme,
+  ) {
+    // When loading, show shimmer (ScheduleShimmer is a ListView, use it directly!)
+    if (examViewModel.loadingState == ExamPhaseLoadingState.loading) {
+      return RefreshIndicator(
+        onRefresh: () => examViewModel.fetchPhaseData(),
+        child: const ScheduleShimmer(),
+      );
+    }
+
+    // When error, show error message with fixed height
+    if (examViewModel.loadingState == ExamPhaseLoadingState.error) {
+      return RefreshIndicator(
+        onRefresh: () => examViewModel.fetchPhaseData(),
+        child: SingleChildScrollView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          child: SizedBox(
+            height: MediaQuery.of(context).size.height * 0.6,
+            child: Center(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  'Failed to load exams.\nPull to refresh.',
+                  textAlign: TextAlign.center,
+                  style: GoogleFonts.almarai(
+                    fontSize: 14,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            ),
           ),
+        ),
+      );
+    }
 
-          // Single Consumer for all exam phase data
-          Consumer<ExamPhaseViewModel>(
-            builder: (context, examViewModel, child) {
-              // Show featured exam (next upcoming) if exists
-              if (examViewModel.nextUpcomingExam != null) {
-                return ExamCardWidget(
-                  exam: examViewModel.nextUpcomingExam!,
-                  countdownText: examViewModel.countdownText,
-                );
-              }
-
+    // Loaded state: Show exam content (has scrollable content)
+    return RefreshIndicator(
+      onRefresh: () => examViewModel.fetchPhaseData(),
+      child: SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Featured exam (next upcoming) if exists
+            if (examViewModel.nextUpcomingExam != null)
+              ExamCardWidget(
+                exam: examViewModel.nextUpcomingExam!,
+                countdownText: examViewModel.countdownText,
+              )
+            else
               // If no upcoming exams, show placeholder
-              return Container(
+              Container(
                 width: double.infinity,
                 margin:
                     const EdgeInsets.symmetric(horizontal: 16, vertical: 0),
@@ -57,29 +112,11 @@ class ExamPhaseWidget extends StatelessWidget {
                     color: theme.colorScheme.error,
                   ),
                 ),
-              );
-            },
-          ),
+              ),
 
-          // Upcoming exams section - included in same Consumer
-          Consumer<ExamPhaseViewModel>(
-            builder: (context, examViewModel, child) {
-              final upcomingExams = examViewModel.upcomingExams;
-
-              if (upcomingExams.isEmpty) {
-                return Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Text(
-                    'No upcoming exams',
-                    style: GoogleFonts.almarai(
-                      fontSize: 13,
-                      color: theme.colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                );
-              }
-
-              return Column(
+            // Upcoming exams section
+            if (examViewModel.upcomingExams.isNotEmpty)
+              Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Padding(
@@ -99,15 +136,25 @@ class ExamPhaseWidget extends StatelessWidget {
                       ),
                     ),
                   ),
-                  ...upcomingExams.map(
+                  ...examViewModel.upcomingExams.map(
                     (exam) => UpcomingExamCardWidget(exam: exam),
                   ),
                   const SizedBox(height: 16),
                 ],
-              );
-            },
-          ),
-        ],
+              )
+            else
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  'No upcoming exams',
+                  style: GoogleFonts.almarai(
+                    fontSize: 13,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/widgets/upcoming_exam_card.dart
+++ b/lib/widgets/upcoming_exam_card.dart
@@ -1,0 +1,80 @@
+import 'package:ecu_scholar/models/exam_model.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:ecu_scholar/constants/text_styles.dart';
+
+class UpcomingExamCardWidget extends StatelessWidget {
+  final Exam exam;
+
+  const UpcomingExamCardWidget({
+    super.key,
+    required this.exam,
+  });
+
+  /// Format date as "Thu, Jun 4"
+  String _formatDate() {
+    return DateFormat('EEE, MMM d').format(exam.startDateTime);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    
+    return Container(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.secondary,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      margin: const EdgeInsets.only(bottom: 8, left: 16, right: 16),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          // Left side - course name and date/time
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  exam.courseName,
+                  style: AppTextStyles.small13w500.copyWith(
+                    color: theme.colorScheme.onSurface,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  '${_formatDate()} · ${exam.startTimeRange}',
+                  style: AppTextStyles.small12.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          // Right side - days remaining and location
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text(
+                '${exam.daysRemaining} day${exam.daysRemaining == 1 ? '' : 's'}',
+                style: AppTextStyles.small13w500.copyWith(
+                  color: theme.colorScheme.error,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                exam.getLocationDisplay(),
+                style: AppTextStyles.small11.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Adds full exam phase support — models, viewmodel, and UI widgets — and refactors the schedule page into smaller, reusable components for better maintainability.

## Changes
`lib/models/exam_model.dart` — Exam model with JSON serialization and utility methods
`lib/models/phase_model.dart` — Phase model definition
`lib/view_models/exam_phase_viewmodel.dart` — ExamPhaseViewModel with data fetching and state management
`lib/widgets/exam_card.dart` — Exam card widget with countdown display
`lib/widgets/exam_phase_widget.dart` — Exam phase UI with shimmer loading and error states
`lib/widgets/upcoming_exam_card.dart` — Upcoming exam card widget
`lib/widgets/day_schedule_widget.dart` — Extracted day schedule into standalone widget
`lib/widgets/date_header.dart` — Extracted date header into standalone widget
`lib/views/schedule_page.dart` — Refactored to use new widgets (-226 lines)
`lib/services/remote_data_service.dart` — Extended to support exam phase data fetching
`lib/constants/text_styles.dart` — Added small text style
`lib/main.dart` — Minor additions

## Checklist
- [ ] Tested on real device
- [X] Shimmer loading displays correctly
- [X] Error state handled gracefully
- [X] Backend integration ready